### PR TITLE
Remove unnecessary (in this case) `deploy_url` argument in makedocs

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -44,7 +44,6 @@ makedocs(
     format   = DocumenterVitepress.MarkdownVitepress(
         repo       = "https://github.com/JuliaClimate/GeoRegions.jl",
         devurl     = "dev",
-        deploy_url = "juliaclimate.github.io/GeoRegions.jl",
     ),
     authors  = "Nathanael Wong",
     sitename = "GeoRegions.jl",


### PR DESCRIPTION
Since this uses the default `user.github.io/repo` workflow, you don't need to set the `deploy_url`.  It seems this is an upstream bug in DocumenterVitepress where it did not recognize the path.

Xref LuxDL/DocumenterVitepress.jl#87